### PR TITLE
Use GHC 9.2.3

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,9 @@ jobs:
       - uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
-            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.garnix.io https://cache.nixos.org/
       - name: Build sources 🔧
         run: |
           nix build -j 4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ The generated HTML site can be previewed here: https://srid.github.io/ema-templa
 To develop with full IDE support in Visual Studio Code, follow these steps:
 
 - [Install Nix](https://nixos.org/download.html) & [enable Flakes](https://nixos.wiki/wiki/Flakes)
-- Run `nix-shell --run haskell-language-server` to sanity check your environment 
+- Setup the [garnix cache](https://garnix.io/docs/caching) (Nix binary cache). This is optional if you are okay with compiling for hours.
+- Run `nix develop -c haskell-language-server` to sanity check your environment 
 - Open the repository [as single-folder workspace](https://code.visualstudio.com/docs/editor/workspaces#_singlefolder-workspaces) in Visual Studio Code
     - Install the recommended extensions
     - <kbd>Ctrl+Shift+P</kbd> to run the command "Nix-Env: Select Environment" and select `shell.nix`. The extension will ask you to reload VSCode at the end.
@@ -19,6 +20,7 @@ All but the final step need to be done only once. Check [the Ema tutorial](https
 
 ## Note
 
+- We are using GHC 9.2 which is not yet the default in `nixpkgs`, so you may want to use the [garnix cache](https://garnix.io/docs/caching) to avoid long compilation.
 - This project uses [relude](https://github.com/kowainik/relude) as its prelude, as well as Tailwind+Blaze as CSS utility and HTML DSL. Even though the author highly recommends them, you are of course free to swap them out for the library of your choice.
   - Tailwind CSS is compiled, alongside Ghcid, via foreman (see `./Procfile`)
 - As a first step to using this template, 

--- a/ema-template.cabal
+++ b/ema-template.cabal
@@ -33,7 +33,6 @@ executable ema-template
     , ema                 >=0.7
     , filepath
     , generic-optics
-    , generics-sop
     , monad-logger
     , optics-core
     , relude

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "lastModified": 1657975505,
+        "narHash": "sha256-juMbw+GY2ycTrg3QbdFfEQs6P3FJeoYEv8aMVl2EZsg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "rev": "d6df226c53d46821bd4773bd7ec3375f30238edb",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1654211622,
-        "narHash": "sha256-N5Xa/JhF9PRgmt+ZVZFaHT7onezENxp7ktnGhhqOBaw=",
+        "lastModified": 1657796772,
+        "narHash": "sha256-4JD3a9frE26VjaJysyd+DIHUJUiWsx/bFrk8tsGMSpU=",
         "owner": "srid",
         "repo": "tailwind-haskell",
-        "rev": "8d08cda7a1cb67435de1ba1739f65e25b303364f",
+        "rev": "96f4c7f8c59eb1103b75ff7d4a753d2d4b9c1ee7",
         "type": "github"
       },
       "original": {
         "owner": "srid",
-        "ref": "master",
         "repo": "tailwind-haskell",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ema": {
       "flake": false,
       "locked": {
-        "lastModified": 1656883550,
-        "narHash": "sha256-l+FzQ0/iWyF1FGu5UoSSaNQcF5AFxQSbceSCk3HERGw=",
+        "lastModified": 1658070756,
+        "narHash": "sha256-2+LrW2TY5+2gTKAyX0DY4RIEavOlwT3xQEfVBT6EyV0=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "929ebf6e7b3eba9fda397a8aa6284dc07b68174e",
+        "rev": "51b0587db1df83f9c835810fbd4914e9f0a76f5e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
               tailwind;
             relude = dontCheck (self.callHackage "relude" "1.1.0.0" { }); # 1.1 not in nixpkgs yet 
             retry = dontCheck super.retry; # For GHC 9.2.
+            streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             relude = dontCheck (self.callHackage "relude" "1.1.0.0" { }); # 1.1 not in nixpkgs yet 
             retry = dontCheck super.retry; # For GHC 9.2.
             streaming-commons = dontCheck super.streaming-commons; # Fails on darwin
+            http2 = dontCheck super.http2; # Fails on darwin
           };
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     # Haskell overrides
     ema.url = "github:srid/ema/multisite";
     ema.flake = false;
-    tailwind-haskell.url = "github:srid/tailwind-haskell/master";
+    tailwind-haskell.url = "github:srid/tailwind-haskell";
     tailwind-haskell.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, haskell-flake, ... }:
@@ -22,16 +22,22 @@
         # "haskellProjects" comes from https://github.com/srid/haskell-flake
         haskellProjects.default = {
           root = ./.;
+          haskellPackages = pkgs.haskell.packages.ghc923;
           buildTools = hp: {
             inherit (pkgs)
               treefmt
               nixpkgs-fmt
               foreman;
             inherit (hp)
-              cabal-fmt
+              # cabal-fmt (Broken on GHC 9.2.3)
               fourmolu;
             inherit (inputs'.tailwind-haskell.packages)
               tailwind;
+
+            # https://github.com/NixOS/nixpkgs/issues/140774 reoccurs in GHC 9.2
+            ghcid = pkgs.haskell.lib.overrideCabal hp.ghcid (drv: {
+              enableSeparateBinOutput = false;
+            });
           };
           source-overrides = {
             inherit (inputs)
@@ -40,6 +46,8 @@
           overrides = self: super: with pkgs.haskell.lib; {
             inherit (inputs'.tailwind-haskell.packages)
               tailwind;
+            relude = dontCheck (self.callHackage "relude" "1.1.0.0" { }); # 1.1 not in nixpkgs yet 
+            retry = dontCheck super.retry; # For GHC 9.2.
           };
         };
       };

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -3,5 +3,6 @@ builds:
     - "packages.x86_64-linux.*"
     - "packages.aarch64-darwin.*"
     - "devShells.x86_64-linux.default"
-    - "devShells.aarch64-darwin.default"
+    # Disabled until https://github.com/garnix-io/issues/issues/22
+    # - "devShells.aarch64-darwin.default"
   exclude: []

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,7 @@
+builds:
+  include:
+    - "packages.x86_64-linux.*"
+    - "packages.aarch64-darwin.*"
+    - "devShells.x86_64-linux.default"
+    - "devShells.aarch64-darwin.default"
+  exclude: []

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,48 +1,49 @@
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Main where
 
 import Data.Generics.Sum.Any (AsAny (_As))
 import Ema
-import Ema.Route.Generic
+import Ema.Route.Generic.TH
 import Ema.Route.Lib.Extra.StaticRoute qualified as SR
-import Generics.SOP qualified as SOP
 import Optics.Core (Prism', (%))
 import Text.Blaze.Html.Renderer.Utf8 qualified as RU
 import Text.Blaze.Html5 ((!))
 import Text.Blaze.Html5 qualified as H
 import Text.Blaze.Html5.Attributes qualified as A
 
-data Route
-  = Route_Html HtmlRoute
-  | Route_Static StaticRoute
-  deriving stock (Eq, Show, Ord, Generic)
-  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
-  deriving
-    (HasSubRoutes, HasSubModels, IsRoute)
-    via ( GenericRoute
-            Route
-            '[ WithModel Model
-             , WithSubRoutes '[HtmlRoute, StaticRoute]
-             ]
-        )
-
-type StaticRoute = SR.StaticRoute "static"
+data Model = Model
+  { modelStatic :: SR.Model
+  }
+  deriving stock (Eq, Show, Generic)
 
 data HtmlRoute
   = HtmlRoute_Index
   | HtmlRoute_About
   deriving stock (Show, Eq, Ord, Generic, Enum, Bounded)
-  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
-  deriving
-    (HasSubRoutes, HasSubModels, IsRoute)
-    via (GenericRoute HtmlRoute '[])
 
-data Model = Model
-  { modelStatic :: SR.Model
-  }
-  deriving stock (Eq, Show, Generic)
+deriveGeneric ''HtmlRoute
+deriveIsRoute ''HtmlRoute [t|'[]|]
+
+type StaticRoute = SR.StaticRoute "static"
+
+data Route
+  = Route_Html HtmlRoute
+  | Route_Static StaticRoute
+  deriving stock (Eq, Show, Ord, Generic)
+
+deriveGeneric ''Route
+deriveIsRoute
+  ''Route
+  [t|
+    [ -- To render a `Route` we need `Model`
+      WithModel Model
+    , -- Override default routes (to avoid its prefiix in URL)
+      WithSubRoutes '[HtmlRoute, StaticRoute]
+    ]
+    |]
 
 instance EmaSite Route where
   siteInput cliAct () = do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -40,8 +40,8 @@ deriveIsRoute
   [t|
     [ -- To render a `Route` we need `Model`
       WithModel Model
-    , -- Override default routes (to avoid its prefiix in URL)
-      WithSubRoutes '[HtmlRoute, StaticRoute]
+    , -- Override default sub-route encoding (to avoid the prefix in encoded URLs)
+      WithSubRoutes [HtmlRoute, StaticRoute]
     ]
     |]
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -37,15 +37,7 @@ data HtmlRoute
   deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
   deriving
     (HasSubRoutes, HasSubModels, IsRoute)
-    via ( GenericRoute
-            HtmlRoute
-            '[ -- Note: On GHC 9.2, WithSubRoutes is automatically determined
-               WithSubRoutes
-                '[ FileRoute "index.html"
-                 , FileRoute "about.html"
-                 ]
-             ]
-        )
+    via (GenericRoute HtmlRoute '[])
 
 data Model = Model
   { modelStatic :: SR.Model

--- a/static/tailwind.css
+++ b/static/tailwind.css
@@ -788,10 +788,6 @@ select {
   display: flex;
 }
 
-.h-1\/4 {
-  height: 25%;
-}
-
 .w-32 {
   width: 8rem;
 }
@@ -810,24 +806,9 @@ select {
   border-radius: 0.25rem;
 }
 
-.bg-rose-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(253 164 175 / var(--tw-bg-opacity));
-}
-
-.bg-gray-300 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(209 213 219 / var(--tw-bg-opacity));
-}
-
 .bg-rose-400 {
   --tw-bg-opacity: 1;
   background-color: rgb(251 113 133 / var(--tw-bg-opacity));
-}
-
-.bg-gray-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
 }
 
 .p-2 {
@@ -853,19 +834,9 @@ select {
   font-weight: 700;
 }
 
-.text-red-500 {
-  --tw-text-opacity: 1;
-  color: rgb(239 68 68 / var(--tw-text-opacity));
-}
-
 .text-white {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
-}
-
-.text-gray-200 {
-  --tw-text-opacity: 1;
-  color: rgb(229 231 235 / var(--tw-text-opacity));
 }
 
 .text-gray-700 {
@@ -876,9 +847,4 @@ select {
 .text-rose-400 {
   --tw-text-opacity: 1;
   color: rgb(251 113 133 / var(--tw-text-opacity));
-}
-
-.hover\:underline:hover {
-  -webkit-text-decoration-line: underline;
-          text-decoration-line: underline;
 }

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -11,10 +11,10 @@ options = [
 ]
 includes = ["*.hs"]
 
-[formatter.cabal]
-command = "cabal-fmt"
-options = ["--inplace"]
-includes = ["*.cabal"]
+# [formatter.cabal]
+# command = "cabal-fmt"
+# options = ["--inplace"]
+# includes = ["*.cabal"]
 
 [formatter.nix]
 command = "nixpkgs-fmt"


### PR DESCRIPTION
Just to avoid having to specify `WithSubRoutes` every time. This does mean that users will have to use garnix cache when basing their app off ema-template. That's a minor inconvenience but it is temporary (until Stackage switches to GHC 9.2).