### PR TITLE
Update nix inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ema": {
       "flake": false,
       "locked": {
-        "lastModified": 1668972953,
-        "narHash": "sha256-WyTqCQg9xPqB2wC16PdjocaIL81MBLtjgC3eCzhN5hE=",
+        "lastModified": 1671908068,
+        "narHash": "sha256-1U5uBaYsH+YT8IFLEzuAqo7H7ifsOQMp8b8FLG38YVs=",
         "owner": "srid",
         "repo": "ema",
-        "rev": "61faae56aa0f3c6ca815f344684cc566f6341662",
+        "rev": "9fc92a132eaeedc4556eb9c17bd79ab7d96c2aaf",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1671322946,
-        "narHash": "sha256-J8Qj+ITV+eti+irTK9Zn2LZVYoIW2g7irPUckU8yZvU=",
+        "lastModified": 1671710971,
+        "narHash": "sha256-YZdt5IJrfsdUTtVB94EMsBvaJbK9ve6QaZyzRuup+sY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3f7172646953bf86dad5953bc45f0edae62ac445",
+        "rev": "98bec08c58a9547d705f2f5e300ac8eef6665e52",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "haskell-flake": {
       "locked": {
-        "lastModified": 1668167720,
-        "narHash": "sha256-5wDTR6xt9BB3BjgKR+YOjOkZgMyDXKaX79g42sStzDU=",
+        "lastModified": 1671460011,
+        "narHash": "sha256-Do7coaucS6ZjNysizQsVPYLLFkq6eQse8n7bzzjAy2I=",
         "owner": "srid",
         "repo": "haskell-flake",
-        "rev": "4fc511d93a55fedf815c1647ad146c26d7a2054e",
+        "rev": "54334cfae9bbb73732bbb1437260017044f68d0b",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1671465334,
-        "narHash": "sha256-wdV5rU+lpn/jYfdj+W6EtFdAz/PrSHHwy8FMWrG4VSw=",
+        "lastModified": 1671493916,
+        "narHash": "sha256-7uvy37mfprmI3fbBw9E+baV1KZHR5zKfSNfPlSiliqo=",
         "owner": "Platonic-Systems",
         "repo": "mission-control",
-        "rev": "cbdbc4e772fe08f856ae4865826f8ecac0af7c3d",
+        "rev": "9acdaa469ebd3c2d6816f8a30c0c217a0da59fe2",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1665349835,
-        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "lastModified": 1671359686,
+        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1670058159,
-        "narHash": "sha256-ERiP2JWanLuGV1PDyHTbcigFCfIi9oco5LFdMJHjREE=",
+        "lastModified": 1671936867,
+        "narHash": "sha256-tOok3/MJWoRUEoPU5Ma/cTCeuw8ACx3Ozu1MlFcdvc8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "49b8ad618e64d9fe9ab686817bfebe047860dcae",
+        "rev": "18ee49839ea8817218c3bfe3a62e06f47a10fdd5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         # "haskellProjects" comes from https://github.com/srid/haskell-flake
         haskellProjects.main = {
           packages.ema-template.root = ./.;
-          haskellPackages = pkgs.haskell.packages.ghc924;
+          haskellPackages = pkgs.haskell.packages.ghc925;
           buildTools = hp: {
             inherit (pkgs)
               treefmt


### PR DESCRIPTION
```
• Updated input 'ema':
    'github:srid/ema/61faae56aa0f3c6ca815f344684cc566f6341662' (2022-11-20)
  → 'github:srid/ema/9fc92a132eaeedc4556eb9c17bd79ab7d96c2aaf' (2022-12-24)
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/3f7172646953bf86dad5953bc45f0edae62ac445' (2022-12-18)
  → 'github:hercules-ci/flake-parts/98bec08c58a9547d705f2f5e300ac8eef6665e52' (2022-12-22)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1?dir=lib' (2022-10-09)
  → 'github:NixOS/nixpkgs/04f574a1c0fde90b51bf68198e2297ca4e7cccf4?dir=lib' (2022-12-18)
• Updated input 'haskell-flake':
    'github:srid/haskell-flake/4fc511d93a55fedf815c1647ad146c26d7a2054e' (2022-11-11)
  → 'github:srid/haskell-flake/54334cfae9bbb73732bbb1437260017044f68d0b' (2022-12-19)
• Updated input 'mission-control':
    'github:Platonic-Systems/mission-control/cbdbc4e772fe08f856ae4865826f8ecac0af7c3d' (2022-12-19)
  → 'github:Platonic-Systems/mission-control/9acdaa469ebd3c2d6816f8a30c0c217a0da59fe2' (2022-12-19)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/49b8ad618e64d9fe9ab686817bfebe047860dcae' (2022-12-03)
  → 'github:nixos/nixpkgs/18ee49839ea8817218c3bfe3a62e06f47a10fdd5' (2022-12-25)
```