### PR TITLE
add UTF8 locale to build script.So file with nonEnglish chars can be …

### DIFF
--- a/nix/modules/flake/packages.nix
+++ b/nix/modules/flake/packages.nix
@@ -11,13 +11,9 @@
           {
              LANG = "C.UTF-8";
              LC_ALL = "C.UTF-8";
-             GHC_IO_ENCODING = "utf-8";
           }
           ''
             mkdir -p $out
-            export LC_ALL
-            export LANG
-            export GHC_IO_ENCODING
             pushd ${inputs.self}/ema-template
             ${lib.getExe config.packages.ema-template} \
               --base-url=${baseUrl} gen $out

--- a/nix/modules/flake/packages.nix
+++ b/nix/modules/flake/packages.nix
@@ -8,9 +8,16 @@
       tailwind = pkgs.haskellPackages.tailwind;
       buildEmaSiteWithTailwind = { baseUrl }:
         pkgs.runCommand "site"
-          { }
+          {
+             LANG = "C.UTF-8";
+             LC_ALL = "C.UTF-8";
+             GHC_IO_ENCODING = "utf-8";
+          }
           ''
             mkdir -p $out
+            export LC_ALL
+            export LANG
+            export GHC_IO_ENCODING
             pushd ${inputs.self}/ema-template
             ${lib.getExe config.packages.ema-template} \
               --base-url=${baseUrl} gen $out


### PR DESCRIPTION
[this issue](https://github.com/srid/ema/issues/173)

files with None-ASCII charactes could not be generated. add UTF8 locale to nix build script. 