### PR TITLE
Idiomatic cleanup: Haskell & Nix

### DIFF
--- a/ema-template/src/Main.hs
+++ b/ema-template/src/Main.hs
@@ -57,7 +57,7 @@ instance EmaSite Route where
       siteOutput (rp % (_As @"Route_Static")) (modelStatic m) r
 
 renderHtmlRoute :: Prism' FilePath Route -> Model -> HtmlRoute -> LByteString
-renderHtmlRoute rp m r = do
+renderHtmlRoute rp m r =
   renderBS $ doctypehtml_ $ do
     head_ $ renderHead rp m r
     body_ [class_ "bg-gray-50"] $ renderBody rp m r
@@ -71,7 +71,7 @@ renderHead rp model r = do
   link_ [rel_ "stylesheet", href_ $ staticRouteUrl rp model "tailwind.css"]
 
 renderBody :: Prism' FilePath Route -> Model -> HtmlRoute -> Html ()
-renderBody rp model r = do
+renderBody rp model r =
   div_ [class_ "container mx-auto mt-8 p-4 max-w-prose border-2 bg-white rounded-lg shadow"] $ do
     renderNavbar rp r
     h1_ [class_ "text-3xl font-bold"] $ toHtml $ routeTitle r
@@ -80,14 +80,15 @@ renderBody rp model r = do
         "You are on the index page. Want to see "
         routeLink rp HtmlRoute_About "About"
         "?"
-      HtmlRoute_About -> do
+      HtmlRoute_About ->
         "You are on the about page."
-    a_ [href_ $ staticRouteUrl rp model "logo.svg", target_ "_blank"] $ do
-      img_ [src_ $ staticRouteUrl rp model "logo.svg", class_ "py-4 w-32", alt_ "Ema Logo"]
+    let logoUrl = staticRouteUrl rp model "logo.svg"
+    a_ [href_ logoUrl, target_ "_blank"] $
+      img_ [src_ logoUrl, class_ "py-4 w-32", alt_ "Ema Logo"]
 
 renderNavbar :: Prism' FilePath Route -> HtmlRoute -> Html ()
 renderNavbar rp currentRoute =
-  nav_ [class_ "w-full text-xl font-bold flex space-x-4  mb-4"] $ do
+  nav_ [class_ "w-full text-xl font-bold flex space-x-4 mb-4"] $
     forM_ (universe @HtmlRoute) $ \r ->
       let extraClass = if r == currentRoute then "bg-rose-400 text-white" else "text-gray-700"
        in a_
@@ -98,7 +99,7 @@ renderNavbar rp currentRoute =
             $ routeTitle r
 
 routeTitle :: HtmlRoute -> Text
-routeTitle r = case r of
+routeTitle = \case
   HtmlRoute_Index -> "Home"
   HtmlRoute_About -> "About"
 
@@ -148,6 +149,5 @@ parseCliArgs =
 
 main :: IO ()
 main = do
-  cliArgs <- parseCliArgs
-  let cfg = SiteConfig (cliArgsEmaCli cliArgs) def
-  void $ Ema.runSiteWith @Route cfg cliArgs
+  args <- parseCliArgs
+  void $ Ema.runSiteWith @Route (SiteConfig (cliArgsEmaCli args) def) args

--- a/nix/modules/flake/devshell.nix
+++ b/nix/modules/flake/devshell.nix
@@ -1,18 +1,17 @@
 {
-  perSystem = { config, pkgs, lib, ... }:
-    {
-      devShells.default = pkgs.mkShell {
-        name = "ema-template";
-        meta.description = "ema-template development environment";
-        packages = [
-          pkgs.tailwindcss
-          pkgs.just
-          pkgs.nixd
-        ];
-        inputsFrom = [
-          config.haskellProjects.default.outputs.devShell
-          config.pre-commit.devShell
-        ];
-      };
+  perSystem = { config, pkgs, ... }: {
+    devShells.default = pkgs.mkShell {
+      name = "ema-template";
+      meta.description = "ema-template development environment";
+      packages = [
+        pkgs.tailwindcss
+        pkgs.just
+        pkgs.nixd
+      ];
+      inputsFrom = [
+        config.haskellProjects.default.outputs.devShell
+        config.pre-commit.devShell
+      ];
     };
+  };
 }

--- a/nix/modules/flake/haskell.nix
+++ b/nix/modules/flake/haskell.nix
@@ -9,7 +9,7 @@
         inputs.ema.haskellFlakeProjectModules.output
       ];
       projectRoot = builtins.toString (lib.fileset.toSource {
-        root = root;
+        inherit root;
         fileset = lib.fileset.unions [
           (root + /ema-template)
           (root + /cabal.project)

--- a/nix/modules/flake/packages.nix
+++ b/nix/modules/flake/packages.nix
@@ -14,7 +14,7 @@
           }
           ''
             mkdir -p $out
-            pushd ${inputs.self}/ema-template
+            cd ${inputs.self}/ema-template
             ${lib.getExe config.packages.ema-template} \
               --base-url=${baseUrl} gen $out
             rm -f $out/tailwind.css


### PR DESCRIPTION
## Summary

- **Haskell**: Remove unnecessary `do` blocks (5 instances), use `\case` for `routeTitle`, deduplicate logo URL via `let` binding, inline single-use `SiteConfig` binding, fix double space in navbar CSS class
- **Nix**: Use `inherit root` instead of `root = root`, flatten unnecessary inner braces in `devshell.nix`, replace `pushd` with `cd` in derivation builder

## Test plan

- [x] `nix run github:juspay/vira -- ci -b` passes (verified after each iteration)